### PR TITLE
feat: write about extracting total_count prop from response

### DIFF
--- a/throwaway/test.md
+++ b/throwaway/test.md
@@ -102,6 +102,7 @@ jobs:
             } \
           "
 ```
+Note: I don't get why this command failed. May revisit it later, but running graphql query using CURL command is quite insane anyway.
 
 ### Experiment 2
 ```
@@ -134,3 +135,33 @@ Result:
 
 ### Experiment 3
 Do the same as experiment 2, but add a new line for outputing it to JSON using jq.
+
+Result: success
+
+### Experiment 4
+Do the same as experiment 3, but extract the `total_count` property only
+
+```
+name: Pull request merged
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  merge_job:
+    name: Check if it's a merged PR
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+    steps:
+      - name: Get PR author
+        run: |
+          echo "This PR was authored by $PR_AUTHOR"
+          curl \
+            -G https://api.github.com/search/issues \
+            --data-urlencode "q=repo:$GITHUB_REPOSITORY is:pr is:closed author:$PR_AUTHOR"
+            -H "Accept: application/vnd.github.v3+json" \
+            | jq '.total_count'
+```


### PR DESCRIPTION
```
name: Pull request merged

on:
  pull_request:
    types: [closed]

jobs:
  merge_job:
    name: Check if it's a merged PR
    if: github.event.pull_request.merged == true
    runs-on: ubuntu-latest
    env:
      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
    steps:
      - name: Get PR author
        run: |
          echo "This PR was authored by $PR_AUTHOR"
          curl \
            -G https://api.github.com/search/issues \
            --data-urlencode "q=repo:$GITHUB_REPOSITORY is:pr is:closed author:$PR_AUTHOR"
            -H "Accept: application/vnd.github.v3+json" \
            | jq '.total_count'
```